### PR TITLE
Bugfix : warning and critical values in graph are wrong

### DIFF
--- a/check_mem
+++ b/check_mem
@@ -13,14 +13,14 @@ if [ "$1" = "-w" ] && [ "$2" -gt "0" ] && [ "$3" = "-c" ] && [ "$4" -gt "0" ]; t
         memUsed_m=$(($memTotal_m-$memFree_m-$memBuffer_m-$memCache_m))
         memUsedPrc=$((($memUsed_m*100)/$memTotal_m))
 
-	warn=$(((($memTotal_m*100)-($memTotal_m*(100-$2)))/100))
-	crit=$(((($memTotal_m*100)-($memTotal_m*(100-$4)))/100))
-
 	memTotal_b=$(($memTotal_m*1024*1024))
 	memFree_b=$(($memFree_m*1024*1024))
 	memUsed_b=$(($memUsed_m*1024*1024))
 	memBuffer_b=$(($memBuffer_m*1024*1024))
 	memCache_b=$(($memCache_m*1024*1024))
+
+        warn=$(((($memTotal_b*100)-($memTotal_b*(100-$2)))/100))
+        crit=$(((($memTotal_b*100)-($memTotal_b*(100-$4)))/100))
 
 	minmax="0;$memTotal_b";
 	data="TOTAL=$memTotal_b;;;$minmax USED=$memUsed_b;$warn;$crit;$minmax CACHE=$memCache_b;;;$minmax BUFFER=$memBuffer_b;;;$minmax"


### PR DESCRIPTION
Hello,

Thanks for your script, it is pretty cool. But i was a bit disappointed to not see my warning and critical values in the PNP4nagios Graph.
The problem is perfdata values are in bytes but the warn and critical values are in megabytes, causing very low thresholds in the graph. 
I fixed this by sending bytes values in perfdata.

Cheers
